### PR TITLE
Fringe correction implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-all = ["HMpTy", "htmcatalog", "paramiko", "scp", "scikit-sparse"]
+all = ["HMpTy", "htmcatalog", "paramiko", "scp", "scikit-sparse",
+        "fringez @ git+https://github.com/m-aubert/fringez.git"]
 
 [project.urls]
 Repository = "https://github.com/MickaelRigault/ztfin2p3"

--- a/ztfin2p3/aperture.py
+++ b/ztfin2p3/aperture.py
@@ -3,6 +3,7 @@
 import os
 import numpy as np
 import ztfimg
+from . import __version__
 from ztfimg.catalog import get_isolated
 from .catalog import get_img_refcatalog
 from .io import ipacfilename_to_ztfin2p3filepath
@@ -267,6 +268,10 @@ def get_aperture_photometry(sciimg, cat="gaia_dr2",
         cat_ = cat.reset_index(drop=True) #Dropping to avoid storing index.
         cat_ = cat_.astype({col : 'float32' for col in cat_.columns[cat_.dtypes == 'float64']})
         merged_cat = cat_.join(ap_dataframe)#.set_index("index")
+        # Manually add version. Should it be current version or Image header version ?
+        # Consider adding master filenames as well ? 
+        #merged_cat['ztfimg_version'] = ztfimg.__version__
+        #merged_cat['ztfin2p3_version'] = __version__
         return merged_cat
 
     return ap_dataframe

--- a/ztfin2p3/aperture.py
+++ b/ztfin2p3/aperture.py
@@ -3,7 +3,6 @@
 import os
 import numpy as np
 import ztfimg
-from . import __version__
 from ztfimg.catalog import get_isolated
 from .catalog import get_img_refcatalog
 from .io import ipacfilename_to_ztfin2p3filepath
@@ -268,10 +267,6 @@ def get_aperture_photometry(sciimg, cat="gaia_dr2",
         cat_ = cat.reset_index(drop=True) #Dropping to avoid storing index.
         cat_ = cat_.astype({col : 'float32' for col in cat_.columns[cat_.dtypes == 'float64']})
         merged_cat = cat_.join(ap_dataframe)#.set_index("index")
-        # Manually add version. Should it be current version or Image header version ?
-        # Consider adding master filenames as well ? 
-        #merged_cat['ztfimg_version'] = ztfimg.__version__
-        #merged_cat['ztfin2p3_version'] = __version__
         return merged_cat
 
     return ap_dataframe

--- a/ztfin2p3/io.py
+++ b/ztfin2p3/io.py
@@ -126,16 +126,16 @@ def get_biasfiles(date, ccdid=None):
     
     return filenames
 
+# ================ #
+#                  #
+#      Fringes     #
+#                  #
+# ================ #
 
+def get_trained_model_path(date='20200723'):
+    FRINGE_MODEL_DIR = os.path.join(LOCALSOURCE, "fringe_model")
 
-
-
-
-
-
-
-
-
+    return os.path.join(FRINGE_MODEL_DIR, date)
 
 # ================ #
 #                  #

--- a/ztfin2p3/pipe/__init__.py
+++ b/ztfin2p3/pipe/__init__.py
@@ -1,2 +1,1 @@
-
 from .calibrationpipe import *

--- a/ztfin2p3/science.py
+++ b/ztfin2p3/science.py
@@ -265,7 +265,7 @@ def build_science_image(
                 quad.set_mask(get_mskdata(fname))
 
             if corr_fringes : 
-                from .utils import correct_fringes_zi
+                from .utils.tools import correct_fringes_zi
                  # Need custom fringez package. For now optional.
                  # In the future corr_fringes will default to True.
                 corr_data = correct_fringes_zi(quad.data, 

--- a/ztfin2p3/science.py
+++ b/ztfin2p3/science.py
@@ -181,6 +181,11 @@ def build_science_image(
     if corr_fringes and filtername != 'zi':
         corr_fringes = False
 
+    if corr_fringes and ccdid == 1 : 
+        w_ = "Reverting to no correction for CCDID 1" 
+        logging.getLogger(__name__).warn(w_)
+        corr_fringes = False
+
     if bias is None:
         biasfile = find_closest_calib_file(
             year, date, ccdid, kind="bias", max_timedelta=max_timedelta

--- a/ztfin2p3/science.py
+++ b/ztfin2p3/science.py
@@ -255,9 +255,6 @@ def build_science_image(
         quads = []
 
         for data, header, fname in zip(new_data, new_header, new_filenames):
-            # Comment out manual addition to header. But needs to be added for versioning.
-            #header['masterflat'] = flatfile
-            #header['masterbias'] = biasfile
             quad = ztfimg.ScienceQuadrant(data=data, header=header)
             if with_mask:
                 quad.set_mask(get_mskdata(fname))

--- a/ztfin2p3/scripts/parse_cal.py
+++ b/ztfin2p3/scripts/parse_cal.py
@@ -42,7 +42,8 @@ def parse_tree(
 @click.command(context_settings={"show_default": True})
 @click.argument("year", nargs=-1)
 @click.option("--clean", is_flag=True, help="keep only complete days?")
-def parse_cal(year, clean):
+@click.option("--prefix", is_flag=False, default='',  help="prefix to file")
+def parse_cal(year, clean, prefix):
     """Parse calibration folder to produce catalogs."""
 
     CAL = pathlib.Path(CAL_DIR)
@@ -77,5 +78,5 @@ def parse_cal(year, clean):
             flat = flat[~flat.PERIOD.isin(to_remove)]
             print(f"{len(bias)} bias, {len(flat)}")
 
-        bias.to_parquet(BIAS / "meta" / f"masterbias_metadata_{y}.parquet")
-        flat.to_parquet(FLAT / "meta" / f"masterflat_metadata_{y}.parquet")
+        bias.to_parquet(BIAS / "meta" / f"{prefix}masterbias_metadata_{y}.parquet")
+        flat.to_parquet(FLAT / "meta" / f"{prefix}masterflat_metadata_{y}.parquet")

--- a/ztfin2p3/utils/tools.py
+++ b/ztfin2p3/utils/tools.py
@@ -158,3 +158,54 @@ def get_healpix_intersect(ra, dec, radius, nside=64, **kwargs):
     # note that inclusive might return too many pixels, 
     # but otherwise we would often miss some
     return hp.query_disc(nside,vec,radius*np.pi/180,inclusive=True,nest=True,**kwargs)
+
+
+# ----------------------------- #
+#      Fringe correction        #
+# ----------------------------- #
+
+#Here for now until no longer optional
+def correct_fringes_zi(image_data, 
+                        mask_data=None, 
+                        image_path=None, 
+                        trained_model_date='20200723' ):
+    from fringez.fringe import remove_fringe # To keep package optional for now
+    from fringez.utils import return_fringe_model_name
+    """
+    Function that gets model to apply and corrects i-band
+    atmospheric fringes.
+
+    Parameters
+    ----------
+
+    image_data: ndarray
+        Image science data in ndarray format with no reodering (if ztfimg)
+
+    mask_data: ndarray 
+        Raw bitmask of image. Array of ints.
+    
+    image_path: str
+        Filename
+    
+    trained_model_date : str
+        Date format 'YYYYMMDD'. Model training date. Default: "20200723"
+
+    Returns
+    -------
+       ndarray 
+            Cleaned image
+        
+        ndarray 
+            Corrective image of fitted fringes
+
+        ndarray 
+            PCA components used to model the fringes.
+    """
+
+
+    fringe_model_path = get_trained_model_path(date=trained_model_date)
+    fringe_model = return_fringe_model_name(image_path, fringe_model_path)
+
+    image_clean, fringe_bias, fringe_proj = remove_fringe(image_data, fringe_model, mask=mask_data)
+
+    return image_clean, fringe_bias, fringe_proj 

--- a/ztfin2p3/utils/tools.py
+++ b/ztfin2p3/utils/tools.py
@@ -169,8 +169,6 @@ def correct_fringes_zi(image_data,
                         mask_data=None, 
                         image_path=None, 
                         trained_model_date='20200723' ):
-    from fringez.fringe import remove_fringe # To keep package optional for now
-    from fringez.utils import return_fringe_model_name
     """
     Function that gets model to apply and corrects i-band
     atmospheric fringes.
@@ -201,7 +199,8 @@ def correct_fringes_zi(image_data,
         ndarray 
             PCA components used to model the fringes.
     """
-
+    from fringez.fringe import remove_fringe # To keep package optional for now
+    from fringez.utils import return_fringe_model_name
 
     fringe_model_path = get_trained_model_path(date=trained_model_date)
     fringe_model = return_fringe_model_name(image_path, fringe_model_path)


### PR DESCRIPTION
1. Implemented fringe correction in `science.build_science_image`.
- Temporary warning on CCD1 (waiting for retraining / or data). Reverts to no correction.
- toml modification to point to fork of fringez (waiting for PR & pypi down the line)
- Modifications to `utils/tools.py` with correction function
- Modifications to `io.py` to point to models.

2. Add prefix to master calib metadata (e.g store without overwriting `clean = False` metadata)

3. Minor docstring fixs.

@MickaelRigault @saimn 