### PR TITLE
Add yaml config file and allow FP_FLATNORM for uncomplete FP

### DIFF
--- a/ztfin2p3/science.py
+++ b/ztfin2p3/science.py
@@ -532,9 +532,9 @@ def compute_fp_norm(flat_files):
     fp_flats_norms = np.median(fp_flats_norms)
 
     for filepath in flat_files:
-        fits.setval(filepath, "HIERARCH FLTNORM_FP", value=fp_flats_norms)
-        #Also record n_ccds used to compute norm for non complete FP.
-        fits.setval(filepath, "HIERARCH NFLATS_FP", value=len(flat_files))
+        with fits.open(filepath, mode="update") as filehandle : 
+            filehandle[0].header["HIERARCH FLTNORM_FP"] = fp_flats_norms
+            filehandle[0].header["HIERARCH NFLATS_FP"] = len(flat_files)
 
     return fp_flats_norms
 

--- a/ztfin2p3/science.py
+++ b/ztfin2p3/science.py
@@ -533,6 +533,8 @@ def compute_fp_norm(flat_files):
 
     for filepath in flat_files:
         fits.setval(filepath, "HIERARCH FLTNORM_FP", value=fp_flats_norms)
+        #Also record n_ccds used to compute norm for non complete FP.
+        fits.setval(filepath, "HIERARCH NFLATS_FP", value=len(flat_files))
 
     return fp_flats_norms
 

--- a/ztfin2p3/scripts/calib.py
+++ b/ztfin2p3/scripts/calib.py
@@ -6,29 +6,31 @@ import rich_click as click
 
 from ztfin2p3.pipe.newpipe import BiasPipe, FlatPipe
 from ztfin2p3.science import compute_fp_norm
-from ztfin2p3.scripts.utils import _run_pdb, init_stats, save_stats, setup_logger
+from ztfin2p3.scripts.utils import (_run_pdb, init_stats, 
+                                    save_stats, setup_logger, get_config_dict)
 
-CLIPPING_PROP = dict(
-    maxiters=1, cenfunc="median", stdfunc="std", masked=False, copy=False
-)
-BIAS_PARAMS = dict(
-    sigma_clip=3,
-    mergedhow="nanmean",
-    clipping_prop=CLIPPING_PROP,
-    get_data_props=dict(overscan_prop=dict(userange=[25, 30])),
-)
-FLAT_PARAMS = dict(
-    corr_pocket=False,
-    sigma_clip=3,
-    mergedhow="nanmean",
-    clipping_prop=CLIPPING_PROP,
-    get_data_props=dict(overscan_prop=dict(userange=[25, 30])),
-)
+#CLIPPING_PROP = dict(
+#    maxiters=1, cenfunc="median", stdfunc="std", masked=False, copy=False
+#)
+#BIAS_PARAMS = dict(
+#    sigma_clip=3,
+#    mergedhow="nanmean",
+#    clipping_prop=CLIPPING_PROP,
+#    get_data_props=dict(overscan_prop=dict(userange=[25, 30])),
+#)
+#FLAT_PARAMS = dict(
+#    corr_pocket=False,
+#    sigma_clip=3,
+#    mergedhow="nanmean",
+#    clipping_prop=CLIPPING_PROP,
+#    get_data_props=dict(overscan_prop=dict(userange=[25, 30])),
+#)
 
 
 @click.command(context_settings={"show_default": True})
 @click.argument("day")
 @click.option("--statsdir", help="path where statistics are stored")
+@click.option("--configpath", help='path to yaml config file')
 @click.option("--suffix", help="suffix for output science files")
 @click.option("--force", "-f", is_flag=True, help="force reprocessing all files?")
 @click.option("--debug", "-d", is_flag=True, help="show debug info?")
@@ -36,6 +38,7 @@ FLAT_PARAMS = dict(
 def calib(
     day,
     statsdir,
+    configpath,
     suffix,
     force,
     debug,
@@ -53,6 +56,11 @@ def calib(
     setup_logger(debug=debug)
     if debug or pdb:
         sys.excepthook = _run_pdb
+
+    cfg = get_config_dict(configpath=config_path, config_key='calib')
+
+    cfg['BIAS_PARAMS'].update(dict(clipping_prop=cfg['CLIPPING_PROP']))
+    cfg['FLAT_PARAMS'].update(dict(clipping_prop=cfg['CLIPPING_PROP']))
 
     n_errors = 0
     day = day.replace("-", "")
@@ -72,10 +80,13 @@ def calib(
                 logger.warning(f"no bias for {day}")
                 n_errors += 1
                 continue
+            
+            #Should add a find nearest calib for bias if bias but no flat ?
+            #How to store this info ? In header ? 
 
             # Generate master bias:
             t0 = time.time()
-            bi.build_ccds(reprocess=force, **BIAS_PARAMS)
+            bi.build_ccds(reprocess=force, **cfg['BIAS_PARAMS'])
             timing = time.time() - t0
             logger.info("bias done, %.2f sec.", timing)
             stats["bias"].append({"ccd": ccdid, "time": timing})
@@ -88,7 +99,7 @@ def calib(
 
             # Generate master flats:
             t0 = time.time()
-            fi.build_ccds(bias=bi, reprocess=force, **FLAT_PARAMS)
+            fi.build_ccds(bias=bi, reprocess=force, **cfg['FLAT_PARAMS'])
             timing = time.time() - t0
             logger.info("flat done, %.2f sec.", timing)
             stats["flat"].append({"ccd": ccdid, "time": timing})
@@ -96,14 +107,16 @@ def calib(
             logger.error("failed: %s", e)
             n_errors += 1
 
-    if n_errors == 0:
-        logger.info("compute flat fp norm")
-        stats["flat norm"] = {}
-        fi = FlatPipe(day, suffix=suffix)
-        for filterid, df in fi.df.groupby("filterid"):
-            logger.debug("filter=%s, %d flats", filterid, len(df))
+    #if n_errors == 0:
+    logger.info("compute flat fp norm")
+    stats["flat norm"] = {}
+    fi = FlatPipe(day, suffix=suffix)
+    for filterid, df in fi.df.groupby("filterid"):
+        logger.debug("filter=%s, %d flats", filterid, len(df))
+        if n_errors == 0 : 
+            #Catching weird issues jic
             assert len(df) == 16
-            stats["flat norm"][filterid] = float(compute_fp_norm(df.fileout.tolist()))
+        stats["flat norm"][filterid] = float(compute_fp_norm(df.fileout.tolist()))
 
     stats["total_time"] = time.time() - tot
     logger.info("all done, %.2f sec.", stats["total_time"])

--- a/ztfin2p3/scripts/config.yml
+++ b/ztfin2p3/scripts/config.yml
@@ -1,0 +1,51 @@
+d2a : 
+  radius : [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  min_max_rad : False
+  corr_pocket : False
+  use_closest_calib : True
+
+  SCI_PARAMS : 
+    fp_flatfield : True
+    overscan_prop : 
+        userange : [25, 30]
+    return_sci_quads : True
+    store : False
+    with_mask : True
+    corr_fringes : False
+    max_timedelta : '10d'
+
+  APER_PARAMS : 
+    cat : "gaia_dr3"
+    apply_proper_motion : True
+    as_path : False
+    minimal_columns : True 
+    seplimit : 20
+    bkgann : None
+    joined : True
+    refcat_radius : 0.7
+
+calib :
+  CLIPPING_PROP  : 
+      maxiters : 1
+      cenfunc : "median"
+      stdfunc : "std"
+      masked : False
+      copy : False
+
+  BIAS_PARAMS  : 
+      sigma_clip : 3
+      mergedhow : "nanmean"
+      get_data_props : 
+        overscan_prop :  
+          userange : [25, 30]
+
+  FLAT_PARAMS  : 
+      corr_pocket : False
+      sigma_clip : 3
+      mergedhow : "nanmean"
+      get_data_props : 
+        overscan_prop : 
+          userange : [25,30]
+
+
+

--- a/ztfin2p3/scripts/config.yml
+++ b/ztfin2p3/scripts/config.yml
@@ -4,7 +4,7 @@ d2a :
   corr_pocket : False
   use_closest_calib : True
 
-  SCI_PARAMS : 
+  sci_params : 
     fp_flatfield : True
     overscan_prop : 
         userange : [25, 30]
@@ -14,7 +14,7 @@ d2a :
     corr_fringes : False
     max_timedelta : '10d'
 
-  APER_PARAMS : 
+  aper_params : 
     cat : "gaia_dr3"
     apply_proper_motion : True
     as_path : False
@@ -25,21 +25,21 @@ d2a :
     refcat_radius : 0.7
 
 calib :
-  CLIPPING_PROP  : 
+  clipping_prop : 
       maxiters : 1
       cenfunc : "median"
       stdfunc : "std"
       masked : False
       copy : False
 
-  BIAS_PARAMS  : 
+  bias : 
       sigma_clip : 3
       mergedhow : "nanmean"
       get_data_props : 
         overscan_prop :  
           userange : [25, 30]
 
-  FLAT_PARAMS  : 
+  flat : 
       corr_pocket : False
       sigma_clip : 3
       mergedhow : "nanmean"

--- a/ztfin2p3/scripts/detrend2aper.py
+++ b/ztfin2p3/scripts/detrend2aper.py
@@ -13,30 +13,33 @@ from ztfin2p3.io import ipacfilename_to_ztfin2p3filepath
 from ztfin2p3.metadata import get_rawmeta, metadata_to_url
 from ztfin2p3.pipe.newpipe import BiasPipe, FlatPipe
 from ztfin2p3.science import build_science_image
-from ztfin2p3.scripts.utils import _run_pdb, init_stats, save_stats, setup_logger
+from ztfin2p3.scripts.utils import (_run_pdb, init_stats, save_stats, 
+                                    setup_logger, get_config_dict)
 
-SCI_PARAMS = dict(
-    corr_fringes=False,
-    fp_flatfield=True,
-    max_timedelta="10d",
-    overscan_prop=dict(userange=[25, 30]),
-    return_sci_quads=True,
-    store=False,
-    with_mask=True,
-)
-APER_PARAMS = dict(
-    cat="gaia_dr3",
-    apply_proper_motion=True,
-    as_path=False,
-    minimal_columns=True,
-    seplimit=20,
-    bkgann=None,
-    joined=True,
-    refcat_radius=0.7,
-)
+#SCI_PARAMS = dict(
+#    corr_fringes=False,
+#    fp_flatfield=True,
+#    max_timedelta="10d",
+#    overscan_prop=dict(userange=[25, 30]),
+#    return_sci_quads=True,
+#    store=False,
+#    with_mask=True,
+#)
+#APER_PARAMS = dict(
+#    cat="gaia_dr3",
+#    apply_proper_motion=True,
+#    as_path=False,
+#    minimal_columns=True,
+#    seplimit=20,
+#    bkgann=None,
+#    joined=True,
+#    refcat_radius=0.7,
+#)
 
 
-def process_sci(rawfile, flat, bias, suffix, radius, corr_pocket, do_aper=True):
+def process_sci(rawfile, flat, bias, suffix, radius, corr_pocket, 
+                do_aper=True, SCI_PARAMS=None, APER_PARAMS=None):
+
     logger = logging.getLogger(__name__)
     quads = build_science_image(
         rawfile,
@@ -87,12 +90,9 @@ def process_sci(rawfile, flat, bias, suffix, radius, corr_pocket, do_aper=True):
 @click.option("--aper", is_flag=True, help="compute aperture photometry?")
 @click.option("--chunk-id", type=int, help="chunk id")
 @click.option("--chunk-size", type=int, help="chunk size")
-@click.option("--radius-min", type=int, default=3, help="minimum aperture radius")
-@click.option("--radius-max", type=int, default=13, help="maximum aperture radius")
+@click.option("--configpath", help='path to yaml config file')
 @click.option("--statsdir", help="path where statistics are stored")
 @click.option("--suffix", help="suffix for output catalogs")
-@click.option("--use-closest-calib", is_flag=True, help="use closest calib?")
-@click.option("--force", "-f", is_flag=True, help="force reprocessing all files?")
 @click.option("--debug", "-d", is_flag=True, help="show debug info?")
 @click.option("--pdb", is_flag=True, help="run pdb if an exception occurs")
 def d2a(
@@ -102,12 +102,9 @@ def d2a(
     aper,
     chunk_id,
     chunk_size,
-    radius_min,
-    radius_max,
+    configpath,
     statsdir,
     suffix,
-    use_closest_calib,
-    force,
     debug,
     pdb,
 ):
@@ -132,7 +129,10 @@ def d2a(
     tot = time.time()
     logger = logging.getLogger(__name__)
     n_errors = 0
-    radius = np.arange(radius_min, radius_max)
+
+    cfg = get_config_dict(config_path=configpath, config_key='d2a')
+    radius = cfg['radius']
+
     stats = init_stats(ccd=ccdid, science=[])
 
     if day is not None:
@@ -146,6 +146,9 @@ def d2a(
             meta["day"] = meta["filefracday"].astype("str").str[:8]
         if "filepath" not in meta.columns:
             meta["filepath"] = metadata_to_url(meta, source="local", datakind="raw")
+
+        # If duplicate filepath (because quadrants info instead of ccd)
+        meta = meta.drop_duplicates(['filepath'])
     else:
         raise ValueError("no day or parquet table")
 
@@ -164,7 +167,7 @@ def d2a(
     stats["nfiles"] = nfiles
 
     for i, (_, row) in enumerate(meta.iterrows(), start=1):
-        if use_closest_calib:
+        if cfg['use_closest_calib']:
             bias = flat = None
         else:
             bi = BiasPipe(row.day, ccdid=ccdid, nskip=10)
@@ -178,8 +181,12 @@ def d2a(
             bias = bi.get_ccd(day=row.day, ccdid=row.ccdid)
             flat = fi.get_ccd(day=row.day, ccdid=row.ccdid, filterid=row.filtercode)
 
-        # pocket effect correction after 20191022
-        corr_pocket = pd.to_datetime(row.day) >= pd.to_datetime("20191022")
+        if cfg['corr_pocket'] : 
+            # pocket effect correction after 20191022
+            corr_pocket = pd.to_datetime(row.day) >= pd.to_datetime("20191022")
+        else : 
+            corr_pocket = False
+
         raw_file = row.filepath
         msg = "processing sci %d/%d filter=%s ccd=%s pocket=%s: %s"
         logger.info(msg, i, nfiles, row.filtercode, row.ccdid, corr_pocket, raw_file)
@@ -192,6 +199,7 @@ def d2a(
             "expid": row.expid,
             "corr_pocket": corr_pocket,
         }
+
         t0 = time.time()
         try:
             aper_stats = process_sci(
@@ -202,6 +210,8 @@ def d2a(
                 radius,
                 corr_pocket=corr_pocket,
                 do_aper=aper,
+                SCI_PARAMS = cfg['SCI_PARAMS'],
+                APER_PARAMS = cfg['APER_PARAMS']
             )
         except Exception as exc:
             if pdb:

--- a/ztfin2p3/scripts/parse_cal.py
+++ b/ztfin2p3/scripts/parse_cal.py
@@ -23,6 +23,7 @@ def parse_tree(
     )
     if "flat" in str(path):
         colnames = colnames + ("FILTRKEY", "FLTNORM")
+        #Might want to add the HIERARCH info but need to consider KeyError in header. 
 
     meta = []
     for date in sorted(os.listdir(path)):
@@ -73,10 +74,17 @@ def parse_cal(year, clean, prefix):
             df = df.fillna(0).astype(int)
             df["tot"] = df[["nbias", "zg", "zi", "zr"]].sum(axis=1)
 
+            # Need to think some more on this operation.
+            # Especially since in the future we might have no bias but flats for a day.
             to_remove = df[df.tot.lt(64)].date.astype(str).tolist()
+
             bias = bias[~bias.PERIOD.isin(to_remove)]
             flat = flat[~flat.PERIOD.isin(to_remove)]
             print(f"{len(bias)} bias, {len(flat)} flats")
+        
+        else : 
+            prefix = 'uncut' 
+            #Hard-code prefix to get no cut metadata and prevent accidental overwriting.
 
         bias.to_parquet(BIAS / "meta" / f"{prefix}masterbias_metadata_{y}.parquet")
         flat.to_parquet(FLAT / "meta" / f"{prefix}masterflat_metadata_{y}.parquet")

--- a/ztfin2p3/scripts/slurm.py
+++ b/ztfin2p3/scripts/slurm.py
@@ -4,7 +4,7 @@ import subprocess
 import pandas as pd
 import rich_click as click
 from ztfin2p3.metadata import get_rawmeta
-from ztfin2p3.scripts.utils import get_config_dict
+from ztfin2p3.scripts.utils import get_config
 
 
 def sbatch(
@@ -60,7 +60,7 @@ def sbatch(
 @click.option("--envpath", help="path to the environment where ztfin2p3 is located")
 @click.option("--logdir", default=".", help="path where logs are stored")
 @click.option("--split-ccds", is_flag=True, help="split CCDs using a job array?")
-@click.option("--configpath", help='path to yaml config file')
+@click.option("--config", default='config.yml', help='path to yaml config file')
 # slurm
 @click.option("--account", default="ztf", help="account to charge resources to")
 @click.option("--cpu-time", "-c", default="2:00:00", help="cputime limit")
@@ -78,7 +78,7 @@ def run(
     envpath,
     logdir,
     split_ccds,
-    configpath,
+    config,
     account,
     cpu_time,
     mem,
@@ -146,9 +146,8 @@ def run(
 
     elif cmd == "d2a":
         
-        cfg = get_config_dict(config_path=configpath, config_key=cmd)
-        corr_pocket = cfg['corr_pocket']
-
+        cfg = get_config(config, command=cmd)
+            
         if date is not None:
             if to is not None:
                 meta = get_rawmeta("science", [date, to], use_dask=False)
@@ -169,9 +168,7 @@ def run(
                 #           but only applied in zi band.
                 #           Could add condition with corr_fringes and filter. 
 
-                #Maybe cleaner way to write below?
-                #Kind of redundant with d2a script as well.
-                corr_pocket = day >= pd.to_datetime("20191022") if corr_pocket else corr_pocket
+                corr_pocket = cfg['corr_pocket'] and pd.to_datetime(row.day) >= pd.to_datetime("20191022")
 
                 if corr_pocket:
                     chunk_size = 100

--- a/ztfin2p3/scripts/slurm.py
+++ b/ztfin2p3/scripts/slurm.py
@@ -4,7 +4,7 @@ import subprocess
 import pandas as pd
 import rich_click as click
 from ztfin2p3.metadata import get_rawmeta
-from ztfin2p3.utils import get_config_dict
+from ztfin2p3.scripts.utils import get_config_dict
 
 
 def sbatch(

--- a/ztfin2p3/scripts/slurm.py
+++ b/ztfin2p3/scripts/slurm.py
@@ -101,7 +101,7 @@ def run(
         logfile = "slurm-%A-%a.log" if array else "slurm-%j.log"
         name = f"ztf_{cmd}"
         if date is not None:
-            name = +f"_{date.replace('-', '')}"
+            name += f"_{date.replace('-', '')}"
         if ccdid is not None:
             name += f"_ccd{ccdid}"
 

--- a/ztfin2p3/scripts/utils.py
+++ b/ztfin2p3/scripts/utils.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pathlib
 from typing import Any
+import yaml
 
 from rich.logging import RichHandler
 from ztfimg import __version__ as ztfimg_version
@@ -62,3 +63,17 @@ def save_stats(stats, statsdir, day=None, ccdid=None):
     stats_file = statsdir / filename
     logger.info("writing stats to %s", stats_file)
     stats_file.write_text(json.dumps(stats))
+
+
+def get_config_dict(config_path='config.yml', config_key=None): 
+    if config_path is None : 
+        config_path = 'config.yml'
+        
+    with open(config_path, 'r') as f : 
+        cfg = yaml.safe_load(f)
+
+    if config_key is not None : 
+        return cfg[config_key]
+    
+    return cfg
+    

--- a/ztfin2p3/scripts/utils.py
+++ b/ztfin2p3/scripts/utils.py
@@ -65,15 +65,13 @@ def save_stats(stats, statsdir, day=None, ccdid=None):
     stats_file.write_text(json.dumps(stats))
 
 
-def get_config_dict(config_path='config.yml', config_key=None): 
-    if config_path is None : 
-        config_path = 'config.yml'
+def get_config(configpath, command=None): 
         
-    with open(config_path, 'r') as f : 
+    with open(configpath, 'r') as f : 
         cfg = yaml.safe_load(f)
 
-    if config_key is not None : 
-        return cfg[config_key]
+    if command is not None : 
+        return cfg[command]
     
     return cfg
     


### PR DESCRIPTION
First attempt to add config.yaml for the ztfin2p3 cmd lines. 
- Cleaned command line arguments for d2a, calib.
- Modified `compute_fp_norm` implementation to track number of ccds used in normalisation computation in header.
-  Some added comments to think on how to do stuff better. 

Draft for now. Would be nice if I could PR that in a branch for iterations.

@saimn 